### PR TITLE
Add support for string slices

### DIFF
--- a/form.go
+++ b/form.go
@@ -109,6 +109,20 @@ func Int(name string, out *int, predicates ...Predicate) Param {
 	}
 }
 
+// StringSlice extracts the string slice of arguments by name
+func StringSlice(name string, out *[]string, predicates ...Predicate) Param {
+	return func(r *http.Request) error {
+		for _, p := range predicates {
+			if err := p.Pass(name, r); err != nil {
+				return err
+			}
+		}
+		*out = make([]string, len(r.Form[name]))
+		copy(*out, r.Form[name])
+		return nil
+	}
+}
+
 // Predicate provides an extensible way to check various conditions on a variable
 // e.g. setting minimums and maximums, or parsing some regular expressions
 type Predicate interface {

--- a/form_test.go
+++ b/form_test.go
@@ -120,6 +120,27 @@ func (s *FormSuite) TestMultipartFormOK(c *C) {
 	c.Assert(d, Equals, 100*time.Second)
 }
 
+func (s *FormSuite) TestStringSliceOK(c *C) {
+	var err error
+	var slice []string
+	var empty []string
+	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		err = Parse(r,
+			StringSlice("slice", &slice),
+			StringSlice("empty", &empty),
+		)
+	})
+	defer srv.Close()
+
+	http.PostForm(srv.URL, url.Values{
+		"slice": []string{"hello1", "hello2"},
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(slice, DeepEquals, []string{"hello1", "hello2"})
+	c.Assert(empty, DeepEquals, []string{})
+}
+
 func serveHandler(f http.HandlerFunc) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(f))
 }


### PR DESCRIPTION
## Purpose

Add ability to accept multiple for arguments with the same name
## Implementation

This PR introduces form.StringSlice that parses the form values into the slice of strings
