### PR TITLE
Simple input validator

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package form
+
+import (
+	"unicode"
+
+	"github.com/gravitational/trace"
+)
+
+// AllowSet is an interface that exposes a single function used to check if
+// input is safe.
+type AllowSet interface {
+	IsSafe(string) error
+}
+
+// CharAllowSet is a set of allowed ASCII characters and a maximum length.
+type CharAllowSet struct {
+	len   int
+	chars [256]bool
+}
+
+// NewCharAllowSet creates a new CharAllowSet.
+func NewCharAllowSet(s string, n int) (CharAllowSet, error) {
+	cas := CharAllowSet{len: n}
+	for _, v := range s {
+		if v > unicode.MaxASCII {
+			return cas, trace.BadParameter("%v [%#x] is outside ASCII range", string(v), v)
+		}
+		cas.chars[int(v)] = true
+	}
+	return cas, nil
+}
+
+// IsSafe checks against CharAllowSet rules.
+func (c CharAllowSet) IsSafe(s string) error {
+	if len(s) > c.len {
+		return trace.BadParameter("length %v is longer than maximum allowable length: %v", len(s), c.len)
+	}
+
+	for _, v := range s {
+		if v > unicode.MaxASCII {
+			return trace.BadParameter("non-ascii character %v [%#x] not allowed", string(v), v)
+		}
+		if c.chars[int(v)] == false {
+			return trace.BadParameter("character %v [%#x] not allowed", string(v), v)
+		}
+	}
+
+	return nil
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package form
+
+import (
+	"fmt"
+
+	"gopkg.in/check.v1"
+)
+
+type AllowSetSuite struct{}
+
+var _ = check.Suite(&AllowSetSuite{})
+var _ = fmt.Printf
+
+func (s *AllowSetSuite) SetUpSuite(c *check.C)    {}
+func (s *AllowSetSuite) TearDownSuite(c *check.C) {}
+func (s *AllowSetSuite) SetUpTest(c *check.C)     {}
+func (s *AllowSetSuite) TearDownTest(c *check.C)  {}
+
+func (s *AllowSetSuite) TestCharAllowSet(c *check.C) {
+	var tests = []struct {
+		inChars           string
+		inLen             int
+		inInput           string
+		outCreateAllowSet bool
+		outIsSafe         bool
+	}{
+		// 0 - length too long
+		{
+			"a",
+			1,
+			"aa",
+			true,
+			false,
+		},
+		// 1 - invalid chars
+		{
+			"a",
+			2,
+			"ab",
+			true,
+			false,
+		},
+		// 2 - non-ascii allowset
+		{
+			"😎",
+			0,
+			"",
+			false,
+			false,
+		},
+		// 3 - non-ascii input
+		{
+			"a",
+			4,
+			"😎",
+			true,
+			false,
+		},
+		// 4 - all good
+		{
+			"a",
+			2,
+			"aa",
+			true,
+			true,
+		},
+	}
+
+	for i, tt := range tests {
+		comment := check.Commentf("Test %v", i)
+
+		as, err := NewCharAllowSet(tt.inChars, tt.inLen)
+		if tt.outCreateAllowSet {
+			c.Assert(err, check.IsNil, comment)
+		} else {
+			c.Assert(err, check.NotNil, comment)
+			continue
+		}
+		err = as.IsSafe(tt.inInput)
+		if tt.outIsSafe {
+			c.Assert(err, check.IsNil, comment)
+		} else {
+			c.Assert(err, check.NotNil, comment)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose**

Added a simple input validator interface called `AllowSet` which requires implementing a single function `IsSafe`. A `CharAllowSet` sanitizer is included that can be used to validator ASCII input.

**Implementation**

* `AllowSet` interface requires implementation of a single function: `IsSafe(string) error`.
* `CharAllowSet` can be used to validate if the input is of a maximum length and contains allowable ASCII characters.