### PR TITLE
Add support for MIME header attributes in a multipart section.

### DIFF
--- a/form.go
+++ b/form.go
@@ -192,7 +192,11 @@ func FileSlice(name string, files *Files, predicates ...Predicate) Param {
 				files.Close()
 				return err
 			}
-			(*files)[i] = &FileWrapper{f, fh.Filename}
+			(*files)[i] = &FileWrapper{
+				File:   f,
+				header: fh.Header,
+				name:   fh.Filename,
+			}
 		}
 		return nil
 	}
@@ -247,12 +251,18 @@ const maxMemoryBytes = 64 * 1024
 
 type FileWrapper struct {
 	multipart.File
-	name string
+	header map[string][]string
+	name   string
 }
 
 // Name returns file name as set during upload
 func (f *FileWrapper) Name() string {
 	return f.name
+}
+
+// Header returns MIME header from the file part
+func (f *FileWrapper) Header() map[string][]string {
+	return f.header
 }
 
 // Files is a slice of multipart.File that provides additional


### PR DESCRIPTION
This change is necessitated by the recent changes to clean up multipart
handling in the stdlib regarding filenames.
See https://github.com/golang/go/commit/784ef4c53135644d70f3476a4bd90010b9acff66 for reference.